### PR TITLE
Add 'transient-option as class for --file-search-regex argument.

### DIFF
--- a/counsel-ag-popup.el
+++ b/counsel-ag-popup.el
@@ -148,6 +148,7 @@ The third arg HISTORY, if non-nil, specifies a history."
 
 (transient-define-argument counsel-ag-popup:-G ()
   :description "Limit search to filenames matching PATTERN"
+  :class 'transient-option
   :shortarg "-G"
   :argument "--file-search-regex="
   :reader 'counsel-ag-popup-read-pattern)


### PR DESCRIPTION
This class appears to be needed for the option to correctly prompt for the regex when specified.